### PR TITLE
Add RTL support, new app strings, and button widget implementation ✅

### DIFF
--- a/lib/core/theming/app_strings/app_string.dart
+++ b/lib/core/theming/app_strings/app_string.dart
@@ -1,5 +1,8 @@
 class AppString {
   static const String appTitle = 'My Store';
   static const String myStore = 'متجري';
-  static const String eachAppleAppsOnYourHand = '! جميع تطبيقات أبل بين يديك';
+  static const String eachAppleAppsOnYourHand = 'جميع تطبيقات أبل بين يديك !';
+  static const String appleStoreIsAStoreThatGiveYou =
+      'متجر التطبيقات المعدلة للأيفون هو عبارة عن متجر يتيح لستخدمي الأيفون الوصول إلي تطبيقات معدلة ومحسنة باشتراك سنوي. يعتبر هذا المتجر بديلًا مثاليًا لمتجر التطبيقات الرسمي، حيث يمكن للمستخدمين تحميل التطبيقات المدفوعة والمحسنة بشكل مجاني في هذا الأشتراك، وكذلك الحصول علي المميزات المميزة التي قد لا تكون متاحة في الإصدارات الرسمية.';
+  static const String continueWithUDID = 'المتابعة بـ استخدام UDID';
 }

--- a/lib/core/theming/app_themes/text_styles.dart
+++ b/lib/core/theming/app_themes/text_styles.dart
@@ -122,6 +122,13 @@ class TextStyles {
     color: Colors.white,
   );
 
+  static TextStyle font14WhiteMedium = TextStyle(
+    fontSize: 14.sp,
+    fontWeight: FontWeightHelper.medium,
+    fontFamily: 'Cairo',
+    color: Colors.white,
+  );
+
   static TextStyle font14BlueSemiBold = TextStyle(
     fontSize: 14.sp,
     fontFamily: 'Cairo',
@@ -145,7 +152,7 @@ class TextStyles {
       fontSize: 18.sp,
       fontFamily: 'Cairo',
       fontWeight: FontWeightHelper.semiBold,
-      color: AppColors.light);
+      color: AppColors.white);
 
   static TextStyle font18WhiteMedium = TextStyle(
     fontSize: 18.sp,

--- a/lib/core/widgets/button_widget.dart
+++ b/lib/core/widgets/button_widget.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:my_store/core/theming/app_colors/app_colors.dart';
+import 'package:my_store/core/theming/app_themes/text_styles.dart';
+
+class ButtonWidget extends StatelessWidget {
+  final VoidCallback onBackPressed;
+  final String btnText;
+  final double width;
+
+  const ButtonWidget(
+      {super.key,
+      required this.onBackPressed,
+      required this.btnText,
+      required this.width});
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: () {
+        onBackPressed();
+      },
+      style: ButtonStyle(
+        backgroundColor: WidgetStateProperty.all(AppColors.blue),
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        minimumSize: WidgetStatePropertyAll(Size(width, 55.h)),
+        shape: WidgetStateProperty.all(
+          RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+        ),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        spacing: 10.w,
+        children: [
+          Text(btnText, style: TextStyles.font16WhiteMedium),
+          Icon(
+            Icons.apple,
+            size: 30.sp,
+            color: AppColors.white,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/my_store/sign_with_udid/sign_with_udid_screen.dart
+++ b/lib/my_store/sign_with_udid/sign_with_udid_screen.dart
@@ -1,10 +1,41 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:my_store/core/helpers/spacing.dart';
+import 'package:my_store/core/theming/app_strings/app_string.dart';
+import 'package:my_store/core/theming/app_themes/text_styles.dart';
+import 'package:my_store/core/widgets/button_widget.dart';
+import 'package:my_store/core/widgets/gradinat_linear_scaffold_background.dart';
 
 class SignWithUdidScreen extends StatelessWidget {
   const SignWithUdidScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Container();
+    return GradientScaffold(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: 14.h,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              AppString.eachAppleAppsOnYourHand,
+              style: TextStyles.font24BlueBold,
+            ),
+            Text(
+              AppString.appleStoreIsAStoreThatGiveYou,
+              style: TextStyles.font14DarkBlueMedium,
+            ),
+            verticalSpace(20),
+            ButtonWidget(
+              onBackPressed: () {},
+              btnText: AppString.continueWithUDID,
+              width: double.infinity,
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/my_store_app.dart
+++ b/lib/my_store_app.dart
@@ -21,6 +21,22 @@ class MyStoreApp extends StatelessWidget {
         initialRoute: Routes.splashScreen,
         onGenerateRoute: appRouter.generateRoute,
         theme: themeDark,
+        builder: (context, child) {
+          // Ensure the app respects the RTL layout globally
+          return Directionality(
+            textDirection: TextDirection.rtl,
+            child: child!,
+          );
+        },
+        // localizationsDelegates: [
+        //   // Add Material and Cupertino localization delegates
+        //   GlobalMaterialLocalizations.delegate,
+        //   GlobalWidgetsLocalizations.delegate,
+        //   GlobalCupertinoLocalizations.delegate,
+        // ],
+        // supportedLocales: const [
+        //   Locale('ar', ''), // Arabic locale
+        // ],
       ),
     );
   }


### PR DESCRIPTION
- RTL Support:
-- Ensured global right-to-left layout using Directionality in the builder method of MaterialApp.
- App Strings: 
-- Updated app_strings.dart to include structured constants for reusable strings.
- Reusable Button Widget:
-- Created a custom CustomButton widget for consistent button styles across the app.
![WhatsApp Image 2025-01-25 at 16 05 11](https://github.com/user-attachments/assets/70125d33-66e7-4269-97e0-e5870983e345)
